### PR TITLE
fix the `files` regex so that yaml files with the official file extension `.yaml` are not ignored

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,6 +2,7 @@
   name: zizmor
   description: 'Find security issues in GitHub Actions CI/CD setups'
   language: python
-  files: \.github/workflows/.*\.yml$
+  types: [yaml]
+  files: \.github/workflows/.*$
   require_serial: true
   entry: zizmor


### PR DESCRIPTION
Currently, yaml files with the [official](https://yaml.org/faq.html) file extension are ignored. With the fix they are also checked without requiring users to override the `files` regex.