### PR TITLE
Allow zizmor to report on all files in one batch

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,4 +3,5 @@
   description: 'Find security issues in GitHub Actions CI/CD setups'
   language: python
   files: \.github/workflows/.*\.yml$
+  require_serial: true
   entry: zizmor


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Right now, pre-commit runs zizmor in parallel, meaning we get a number of separate summaries of the files.

pre-commit has this setting:

> `require_serial`: (optional: default `false`) if `true` this hook will execute using a single process instead of in parallel.

https://pre-commit.com/#hooks-require_serial

Black also uses it:

https://github.com/psf/black-pre-commit-mirror/blob/c53240a7f974b3707e13eac6710542cc96a2d61a/.pre-commit-hooks.yaml#L7

## Test Plan

<!-- How was it tested? -->

```
git clone https://github.com/python/cpython
cd cpython
```
Then add zizmor to the pre-commit config:

```yml
  - repo: https://github.com/woodruffw/zizmor-pre-commit
    rev: v0.8.0
    hooks:
      - id: zizmor
```

Then run it:
```sh
pre-commit run --all-files zizmor
```
And get separate findings, making it hard to see the overview:

```
...
30 findings (19 suppressed): 0 unknown, 0 informational, 7 low, 4 medium, 0 high
...
38 findings (35 suppressed): 0 unknown, 0 informational, 1 low, 0 medium, 2 high
...
23 findings (20 suppressed): 0 unknown, 0 informational, 0 low, 0 medium, 3 high
...
16 findings (10 suppressed): 0 unknown, 0 informational, 6 low, 0 medium, 0 high
...
6 findings (5 suppressed): 0 unknown, 0 informational, 0 low, 0 medium, 1 high
```

But with this branch:
```yml
  - repo: https://github.com/hugovk/zizmor-pre-commit
    rev: require_serial
    hooks:
      - id: zizmor
```

We get a single summary:
```
...
113 findings (89 suppressed): 0 unknown, 0 informational, 14 low, 4 medium, 6 high
```




