### PR TITLE
pre-commit: tell zizmor to audit the whole repo

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,8 +1,8 @@
 - id: zizmor
   name: zizmor
-  description: 'Find security issues in GitHub Actions CI/CD setups'
+  description: "Find security issues in GitHub Actions CI/CD setups"
   language: python
   types: [yaml]
-  files: \.github/workflows/.*$
+  files: \.
   require_serial: true
   entry: zizmor

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,6 +3,5 @@
   description: "Find security issues in GitHub Actions CI/CD setups"
   language: python
   types: [yaml]
-  files: \.
   require_serial: true
   entry: zizmor

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,6 @@
   description: "Find security issues in GitHub Actions CI/CD setups"
   language: python
   types: [yaml]
+  files: (\.github/workflows/.*)|(action\.ya?ml)$
   require_serial: true
   entry: zizmor


### PR DESCRIPTION
This changes the default `files:` configuration to pass `.` to `zizmor`, rather than just the `.github/workflows` directory.

This is needed for a reasonable default now that (as of 1.0) zizmor supports auditing composite actions, which can be anywhere in the repo.

CC @graingert to sanity-check me here, since I'm not 100% sure directories can go in `files:` :slightly_smiling_face: 

See https://github.com/woodruffw/zizmor/issues/399