### PR TITLE
README: remove pyversion badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![image](https://img.shields.io/pypi/v/zizmor/1.6.0.svg)](https://pypi.python.org/pypi/zizmor)
 [![image](https://img.shields.io/pypi/l/zizmor/1.6.0.svg)](https://pypi.python.org/pypi/zizmor)
-[![image](https://img.shields.io/pypi/pyversions/zizmor/1.6.0.svg)](https://pypi.python.org/pypi/zizmor)
 [![Actions status](https://github.com/woodruffw/zizmor-pre-commit/workflows/main/badge.svg)](https://github.com/woodruffw/zizmor-pre-commit/actions)
 
 A [pre-commit](https://pre-commit.com/) hook for [Zizmor](https://github.com/woodruffw/zizmor).


### PR DESCRIPTION
This is a Rust package with no relevant Python version.

